### PR TITLE
Changes for track 2 Key Client

### DIFF
--- a/azure-keyvault/azure/keyvault/keys/__init__.py
+++ b/azure-keyvault/azure/keyvault/keys/__init__.py
@@ -1,5 +1,4 @@
 from ._client import KeyClient
 from ._models import Key, KeyBase, DeletedKey
 
-# TODO:
 __all__ = ["DeletedKey", "Key", "KeyBase", "KeyClient"]

--- a/azure-keyvault/azure/keyvault/keys/_client.py
+++ b/azure-keyvault/azure/keyvault/keys/_client.py
@@ -482,7 +482,7 @@ class KeyClient:
         response = self._pipeline.run(request, **kwargs).http_response
         if response.status_code != 200:
             raise ClientRequestError("Request failed status code {}.  {}".format(response.status_code, response.text()))
-        # should this return key attributes or key ?
+        
         bundle = DESERIALIZE("KeyBundle", response)
 
         return Key._from_key_bundle(bundle)

--- a/azure-keyvault/azure/keyvault/keys/_models.py
+++ b/azure-keyvault/azure/keyvault/keys/_models.py
@@ -150,7 +150,7 @@ class DeletedKey(Key):
         scheduled_purge_date=None,
         **kwargs
     ):
-        # type: (models.JsonWebKey, str, models.JsonWebKey, Optional[datetime], Optional[str], Optional[datetime], Mapping[str, Any]) -> None
+        # type: (models.KeyAttributes, str, models.JsonWebKey, Optional[datetime], Optional[str], Optional[datetime], Mapping[str, Any]) -> None
         super(DeletedKey, self).__init__(attributes, vault_id, key_material, **kwargs)
         self._deleted_date = deleted_date
         self._recovery_id = recovery_id


### PR DESCRIPTION
This PR adds a layer over autorest-generated models.

KeyAttributes exposes a key's common attributes but not its jsonWebKey (key/key_material). Most client methods return this.
Key is KeyAttributes plus a jsonWebKey
DeletedKey is KeyAttributes plus deletion/recovery/purge information

TODO's left:
`wrap_key`, `unwrap_key`, `import_key`.
