### PR TITLE
Make None tenant_id default to organizations

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -90,7 +90,7 @@ class MsalCredential(ABC):
             tenant_id = self._profile.tenant_id
         else:
             authority = kwargs.pop("authority", None) or get_default_authority()
-            tenant_id = kwargs.pop("tenant_id", "organizations")
+            tenant_id = kwargs.pop("tenant_id", None) or "organizations"
 
         self._base_url = "https://" + "/".join((authority.strip("/"), tenant_id.strip("/")))
         self._client_credential = client_credential


### PR DESCRIPTION
Make `None` `tenant_id` default to `"organizations"`. Otherwise, passing in `tenant_id=None` causes L95 to fail. 