### PR TITLE
BearerTokenCredentialPolicy supports CAE

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -3,10 +3,14 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
+import base64
+from collections import namedtuple
+import re
 import time
 import six
 
-from . import SansIOHTTPPolicy
+from . import HTTPPolicy, SansIOHTTPPolicy
+from .._tools import await_result
 from ...exceptions import ServiceRequestError
 
 try:
@@ -16,9 +20,10 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
-    from typing import Any, Dict, Optional
+    from typing import Any, Dict, List, Optional
     from azure.core.credentials import AccessToken, TokenCredential, AzureKeyCredential, AzureSasCredential
     from azure.core.pipeline import PipelineRequest
+    from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 
 # pylint:disable=too-few-public-methods
@@ -71,27 +76,111 @@ class _BearerTokenCredentialPolicyBase(object):
         return not self._token or self._token.expires_on - time.time() < 300
 
 
-class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, SansIOHTTPPolicy):
+class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy):
     """Adds a bearer token Authorization header to requests.
 
-    :param credential: The credential.
-    :type credential: ~azure.core.TokenCredential
-    :param str scopes: Lets you specify the type of access needed.
-    :raises: :class:`~azure.core.exceptions.ServiceRequestError`
+    :param ~azure.core.credentials.TokenCredential credential: credential for authorizing requests
+    :param str scopes: required authentication scopes
     """
 
     def on_request(self, request):
-        # type: (PipelineRequest) -> None
+        """This method is for backward compatibility. It has no implementation."""
+
+    def on_response(self, request, response):
+        """This method is for backward compatibility. It has no implementation."""
+
+    def on_exception(self, request):
+        """This method is for backward compatibility. It has no implementation."""
+
+    def send(self, request):
+        # type: (PipelineRequest) -> PipelineResponse
         """Adds a bearer token Authorization header to request and sends request to next policy.
 
-        :param request: The pipeline request object
-        :type request: ~azure.core.pipeline.PipelineRequest
+        :param ~azure.core.pipeline.PipelineRequest request: The request
         """
+
+        # this is copied from SansIOHTTPPolicy for backward compatibility
+        await_result(self.on_request, request)
+        try:
+            response = self._send(request)
+        except Exception:  # pylint: disable=broad-except
+            if not await_result(self.on_exception, request):
+                raise
+        else:
+            await_result(self.on_response, request, response)
+        return response
+
+    def _send(self, request):
+        # type: (PipelineRequest) -> PipelineResponse
         self._enforce_https(request)
+        self.on_before_request(request)
+
+        response = self.next.send(request)
+
+        if response.http_response.status_code == 401:
+            self._token = None  # any cached token is invalid
+            challenge = response.http_response.headers.get("WWW-Authenticate")
+            if challenge and self.on_challenge(request, challenge):
+                response = self.next.send(request)
+
+        return response
+
+    def on_before_request(self, request):
+        # type: (PipelineRequest) -> None
+        """Executed before sending the request.
+
+        Base implementation authorizes `request`, acquiring an access token as necessary.
+        """
 
         if self._token is None or self._need_new_token:
             self._token = self._credential.get_token(*self._scopes)
         self._update_headers(request.http_request.headers, self._token.token)
+
+    def on_challenge(self, request, challenge):
+        # type: (PipelineRequest, str) -> bool
+        """Authorize request according to an authentication challenge.
+
+        Base implementation handles CAE claims directives. Clients expecting other challenges must override.
+
+        :param ~azure.core.pipeline.PipelineRequest request: the request which elicited an authentication challenge
+        :param str challenge: the response's WWW-Authenticate header, unparsed. It may contain multiple challenges.
+        :return: a bool indicating whether the method satisfied the challenge
+        """
+
+        parsed_challenges = _parse_challenges(challenge)
+        if len(parsed_challenges) != 1 or "claims" not in parsed_challenges[0].parameters:
+            # no or multiple challenges, or no claims directive
+            return False
+
+        encoded_claims = parsed_challenges[0].parameters["claims"]
+        padding_needed = 4 - len(encoded_claims) % 4
+        try:
+            claims = base64.urlsafe_b64decode(encoded_claims + "=" * padding_needed).decode()
+        except Exception:  # pylint:disable=broad-except
+            return False
+
+        self._token = self._credential.get_token(*self._scopes, claims_challenge=claims)
+        self._update_headers(request.http_request.headers, self._token.token)
+        return True
+
+
+# these expressions are for challenges with comma delimited parameters having quoted values, e.g.
+# Bearer authorization="https://login.microsoftonline.com/", resource="https://vault.azure.net"
+_AUTHENTICATION_CHALLENGE = re.compile(r'(?:(\w+) ((?:\w+=".*?"(?:, )?)+)(?:, )?)')
+_CHALLENGE_PARAMETER = re.compile(r'(?:(\w+)="([^"]*)")+')
+
+_AuthenticationChallenge = namedtuple("_AuthenticationChallenge", "scheme,parameters")
+
+
+def _parse_challenges(header):
+    # type: (str) -> List[_AuthenticationChallenge]
+    result = []
+    challenges = re.findall(_AUTHENTICATION_CHALLENGE, header)
+    for scheme, parameter_list in challenges:
+        parameters = re.findall(_CHALLENGE_PARAMETER, parameter_list)
+        challenge = _AuthenticationChallenge(scheme, dict(parameters))
+        result.append(challenge)
+    return result
 
 
 class AzureKeyCredentialPolicy(SansIOHTTPPolicy):

--- a/sdk/core/azure-core/tests/test_authentication.py
+++ b/sdk/core/azure-core/tests/test_authentication.py
@@ -3,13 +3,21 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
+import base64
+import itertools
 import time
 
 import azure.core
 from azure.core.credentials import AccessToken, AzureKeyCredential, AzureSasCredential
 from azure.core.exceptions import ServiceRequestError
 from azure.core.pipeline import Pipeline
-from azure.core.pipeline.policies import BearerTokenCredentialPolicy, SansIOHTTPPolicy, AzureKeyCredentialPolicy, AzureSasCredentialPolicy
+from azure.core.pipeline.policies import (
+    BearerTokenCredentialPolicy,
+    SansIOHTTPPolicy,
+    AzureKeyCredentialPolicy,
+    AzureSasCredentialPolicy,
+)
+from azure.core.pipeline.policies._authentication import _parse_challenges
 from azure.core.pipeline.transport import HttpRequest
 
 import pytest
@@ -28,6 +36,7 @@ def test_bearer_policy_adds_header():
 
     def verify_authorization_header(request):
         assert request.http_request.headers["Authorization"] == "Bearer {}".format(expected_token.token)
+        return Mock()
 
     fake_credential = Mock(get_token=Mock(return_value=expected_token))
     policies = [BearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_authorization_header)]
@@ -41,6 +50,7 @@ def test_bearer_policy_adds_header():
 
     # Didn't need a new token
     assert fake_credential.get_token.call_count == 1
+
 
 def test_bearer_policy_send():
     """The bearer token policy should invoke the next policy's send method and return the result"""
@@ -86,6 +96,7 @@ def test_bearer_policy_optionally_enforces_https():
 
     def assert_option_popped(request, **kwargs):
         assert "enforce_https" not in kwargs, "BearerTokenCredentialPolicy didn't pop the 'enforce_https' option"
+        return Mock()
 
     credential = Mock(get_token=lambda *_, **__: AccessToken("***", 42))
     pipeline = Pipeline(
@@ -113,8 +124,10 @@ def test_preserves_enforce_https_opt_out():
     class ContextValidator(SansIOHTTPPolicy):
         def on_request(self, request):
             assert "enforce_https" in request.context, "'enforce_https' is not in the request's context"
+            return Mock()
 
-    policies = [BearerTokenCredentialPolicy(credential=Mock(), scope="scope"), ContextValidator()]
+    credential = Mock(get_token=Mock(return_value=AccessToken("***", 42)))
+    policies = [BearerTokenCredentialPolicy(credential, "scope"), ContextValidator()]
     pipeline = Pipeline(transport=Mock(), policies=policies)
 
     pipeline.run(HttpRequest("GET", "http://not.secure"), enforce_https=False)
@@ -127,10 +140,213 @@ def test_context_unmodified_by_default():
         def on_request(self, request):
             assert not any(request.context), "the policy shouldn't add to the request's context"
 
-    policies = [BearerTokenCredentialPolicy(credential=Mock(), scope="scope"), ContextValidator()]
+    credential = Mock(get_token=Mock(return_value=AccessToken("***", 42)))
+    policies = [BearerTokenCredentialPolicy(credential, "scope"), ContextValidator()]
     pipeline = Pipeline(transport=Mock(), policies=policies)
 
     pipeline.run(HttpRequest("GET", "https://secure"))
+
+
+def test_challenge_parsing():
+    challenges = (
+        (  # CAE - insufficient claims
+            'Bearer realm="", authorization_uri="https://login.microsoftonline.com/common/oauth2/authorize", client_id="00000003-0000-0000-c000-000000000000", error="insufficient_claims", claims="eyJhY2Nlc3NfdG9rZW4iOiB7ImZvbyI6ICJiYXIifX0="',
+            {
+                "authorization_uri": "https://login.microsoftonline.com/common/oauth2/authorize",
+                "client_id": "00000003-0000-0000-c000-000000000000",
+                "error": "insufficient_claims",
+                "claims": "eyJhY2Nlc3NfdG9rZW4iOiB7ImZvbyI6ICJiYXIifX0=",
+                "realm": "",
+            },
+        ),
+        (  # CAE - sessions revoked
+            'Bearer authorization_uri="https://login.windows-ppe.net/", error="invalid_token", error_description="User session has been revoked", claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwMzc0MjgwMCJ9fX0="',
+            {
+                "authorization_uri": "https://login.windows-ppe.net/",
+                "error": "invalid_token",
+                "error_description": "User session has been revoked",
+                "claims": "eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwMzc0MjgwMCJ9fX0=",
+            },
+        ),
+        (  # CAE - IP policy
+            'Bearer authorization_uri="https://login.windows.net/", error="invalid_token", error_description="Tenant IP Policy validate failed.", claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwidmFsdWUiOiIxNjEwNTYzMDA2In0sInhtc19ycF9pcGFkZHIiOnsidmFsdWUiOiIxLjIuMy40In19fQ"',
+            {
+                "authorization_uri": "https://login.windows.net/",
+                "error": "invalid_token",
+                "error_description": "Tenant IP Policy validate failed.",
+                "claims": "eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwidmFsdWUiOiIxNjEwNTYzMDA2In0sInhtc19ycF9pcGFkZHIiOnsidmFsdWUiOiIxLjIuMy40In19fQ"
+            }
+        ),
+        (  # Key Vault
+            'Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47", resource="https://vault.azure.net"',
+            {
+                "authorization": "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "resource": "https://vault.azure.net",
+            },
+        ),
+        (  # ARM
+            'Bearer authorization_uri="https://login.windows.net/", error="invalid_token", error_description="The authentication failed because of missing \'Authorization\' header."',
+            {
+                "authorization_uri": "https://login.windows.net/",
+                "error": "invalid_token",
+                "error_description": "The authentication failed because of missing 'Authorization' header.",
+            },
+        ),
+    )
+
+    for challenge, expected_parameters in challenges:
+        challenge = _parse_challenges(challenge)
+        assert len(challenge) == 1
+        assert challenge[0].scheme == "Bearer"
+        assert challenge[0].parameters == expected_parameters
+
+    for permutation in itertools.permutations(challenge for challenge, _ in challenges):
+        parsed_challenges = _parse_challenges(", ".join(permutation))
+        assert len(parsed_challenges) == len(challenges)
+        expected_parameters = [parameters for _, parameters in challenges]
+        for challenge in parsed_challenges:
+            assert challenge.scheme == "Bearer"
+            expected_parameters.remove(challenge.parameters)
+        assert len(expected_parameters) == 0
+
+
+def test_calls_on_before_request():
+    """BearerTokenCredentialPolicy should call on_before_request before sending a request"""
+
+    transport = Mock()
+
+    class TestPolicy(BearerTokenCredentialPolicy):
+        called = False
+
+        def on_before_request(self, request):
+            assert not transport.send.called
+            self.__class__.called = True
+
+    pipeline = Pipeline(policies=[TestPolicy(Mock(), "scope")], transport=transport)
+    pipeline.run(HttpRequest("GET", "https://localhost"))
+
+    assert TestPolicy.called
+    assert transport.send.call_count == 1
+
+
+def test_calls_on_challenge():
+    """BearerTokenCredentialPolicy should call its on_challenge method when it receives an authentication challenge"""
+
+    class TestPolicy(BearerTokenCredentialPolicy):
+        called = False
+
+        def on_challenge(self, request, challenge):
+            self.__class__.called = True
+            return False
+
+    credential = Mock(get_token=Mock(return_value=AccessToken("***", int(time.time()) + 3600)))
+    policies = [TestPolicy(credential, "scope")]
+    response = Mock(status_code=401, headers={"WWW-Authenticate": 'Basic realm="localhost"'})
+    transport = Mock(send=Mock(return_value=response))
+
+    pipeline = Pipeline(transport=transport, policies=policies)
+    pipeline.run(HttpRequest("GET", "https://localhost"))
+
+    assert TestPolicy.called
+
+
+def test_cannot_complete_challenge():
+    """BearerTokenCredentialPolicy should return the 401 response when it can't complete its challenge"""
+
+    expected_scope = "scope"
+    expected_token = AccessToken("***", int(time.time()) + 3600)
+    credential = Mock(get_token=Mock(return_value=expected_token))
+    expected_response = Mock(status_code=401, headers={"WWW-Authenticate": 'Basic realm="localhost"'})
+    transport = Mock(send=Mock(return_value=expected_response))
+    policies = [BearerTokenCredentialPolicy(credential, expected_scope)]
+
+    pipeline = Pipeline(transport=transport, policies=policies)
+    response = pipeline.run(HttpRequest("GET", "https://localhost"))
+
+    assert response.http_response is expected_response
+    assert transport.send.call_count == 1
+    credential.get_token.assert_called_once_with(expected_scope)
+
+
+def test_claims_challenge():
+    """BearerTokenCredentialPolicy should pass claims from an authentication challenge to its credential"""
+
+    first_token = AccessToken("first", int(time.time()) + 3600)
+    second_token = AccessToken("second", int(time.time()) + 3600)
+    tokens = (t for t in (first_token, second_token))
+
+    expected_claims = '{"access_token": {"essential": "true"}'
+    expected_scope = "scope"
+
+    challenge = 'Bearer claims="{}"'.format(base64.b64encode(expected_claims.encode()).decode())
+    responses = (r for r in (Mock(status_code=401, headers={"WWW-Authenticate": challenge}), Mock(status_code=200)))
+
+    def send(request):
+        res = next(responses)
+        if res.status_code == 401:
+            expected_token = first_token.token
+        else:
+            expected_token = second_token.token
+        assert request.headers["Authorization"] == "Bearer " + expected_token
+
+        return res
+
+    def get_token(*scopes, **kwargs):
+        assert scopes == (expected_scope,)
+        return next(tokens)
+
+    credential = Mock(get_token=Mock(wraps=get_token))
+    transport = Mock(send=Mock(wraps=send))
+    policies = [BearerTokenCredentialPolicy(credential, expected_scope)]
+    pipeline = Pipeline(transport=transport, policies=policies)
+
+    response = pipeline.run(HttpRequest("GET", "https://localhost"))
+
+    assert response.http_response.status_code == 200
+    assert transport.send.call_count == 2
+    assert credential.get_token.call_count == 2
+    credential.get_token.assert_called_with(expected_scope, claims_challenge=expected_claims)
+    with pytest.raises(StopIteration):
+        next(tokens)
+    with pytest.raises(StopIteration):
+        next(responses)
+
+
+def test_calls_prior_base_class_methods():
+    """Backcompat requires BearerTokenCredentialPolicy to behave like SansIOHttpPolicy"""
+
+    class TestPolicy(BearerTokenCredentialPolicy):
+        def __init__(self, *args, **kwargs):
+            super(TestPolicy, self).__init__(*args, **kwargs)
+            self.on_exception = Mock(return_value=None)
+            self.on_request = Mock()
+            self.on_response = Mock()
+
+        def send(self, request):
+            self.request = request
+            self.response = super(TestPolicy, self).send(request)
+            return self.response
+
+    credential = Mock(get_token=Mock(return_value=AccessToken("***", int(time.time()) + 3600)))
+    policy = TestPolicy(credential, "scope")
+    transport = Mock(send=Mock(return_value=Mock(status_code=200)))
+
+    pipeline = Pipeline(transport=transport, policies=[policy])
+    pipeline.run(HttpRequest("GET", "https://localhost"))
+
+    policy.on_request.assert_called_once_with(policy.request)
+    policy.on_response.assert_called_once_with(policy.request, policy.response)
+
+    # on_exception should be called when send() raises
+    class TestException(Exception):
+        pass
+
+    credential = Mock(get_token=Mock(side_effect=TestException))
+    policy = TestPolicy(credential, "scope")
+    pipeline = Pipeline(transport=transport, policies=[policy])
+    with pytest.raises(TestException):
+        pipeline.run(HttpRequest("GET", "https://localhost"))
+    policy.on_exception.assert_called_once_with(policy.request)
 
 
 @pytest.mark.skipif(azure.core.__version__ >= "2", reason="this test applies only to azure-core 1.x")
@@ -153,6 +369,7 @@ def test_key_vault_regression():
     assert not policy._need_new_token
     assert policy._token.token == token
 
+
 def test_azure_key_credential_policy():
     """Tests to see if we can create an AzureKeyCredentialPolicy"""
 
@@ -162,12 +379,13 @@ def test_azure_key_credential_policy():
     def verify_authorization_header(request):
         assert request.headers[key_header] == api_key
 
-    transport=Mock(send=verify_authorization_header)
+    transport = Mock(send=verify_authorization_header)
     credential = AzureKeyCredential(api_key)
     credential_policy = AzureKeyCredentialPolicy(credential=credential, name=key_header)
     pipeline = Pipeline(transport=transport, policies=[credential_policy])
 
     pipeline.run(HttpRequest("GET", "https://test_key_credential"))
+
 
 def test_azure_key_credential_policy_raises():
     """Tests AzureKeyCredential and AzureKeyCredentialPolicy raises with non-string input parameters."""
@@ -179,6 +397,7 @@ def test_azure_key_credential_policy_raises():
     credential = AzureKeyCredential(str(api_key))
     with pytest.raises(TypeError):
         credential_policy = AzureKeyCredentialPolicy(credential=credential, name=key_header)
+
 
 def test_azure_key_credential_updates():
     """Tests AzureKeyCredential updates"""


### PR DESCRIPTION
This extends BearerTokenCredentialPolicy to support CAE, using extension points subclasses can use to support other challenge formats. The extension points are two new methods:
1. the policy calls `on_before_request` (name suggestions welcome) before it sends a request
    - base implementation authorizes the request
2. the policy calls `on_challenge` when it receives a 401 response with a WWW-Authenticate header
    - base implementation handles CAE challenges

Because the policy must examine responses, I changed its base class from SansIOHTTPPolicy to HTTPPolicy, and added empty implementations of the former's methods to preserve compatibility. I think that's ugly, and I'm open to creating a new policy instead, but I like extending the existing policy for a first beta because it allows management libraries to support CAE without any code change.